### PR TITLE
don't build snuba rust

### DIFF
--- a/examples/new_replica/docker-compose.yml
+++ b/examples/new_replica/docker-compose.yml
@@ -114,6 +114,8 @@ services:
         build:
             context: ~/snuba
             dockerfile: Dockerfile
+            args:
+                - SHOULD_BUILD_RUST=false
         ports:
             - "1218:1218"
         environment:


### PR DESCRIPTION
once https://github.com/getsentry/snuba/pull/3907 is added we can add this flag, it saves a lot of time when building the snuba image if you need to test out changes in snuba against the cluster